### PR TITLE
Update to nan 1.5.1 - iojs support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "bindings": "~1.2.1",
     "debug": "~2.1.0",
-    "nan": "~1.4.1"
+    "nan": "~1.5.3"
   },
   "devDependencies": {
     "vows": ">=0.5.12",


### PR DESCRIPTION
Updated nan to 1.5.1 for iojs support.