### PR TITLE
Dependency fixes, suppression of compilation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,13 @@ npm install node-expat
 
 ## Testing
 
+If not already available globally, you'll need to install the
+[standard](http://standardjs.com/) code style checker.
+
+```
+npm install standard
+```
+
 ```
 npm test
 ```
-

--- a/deps/libexpat/libexpat.gyp
+++ b/deps/libexpat/libexpat.gyp
@@ -55,6 +55,14 @@
         'PIC',
         'HAVE_EXPAT_CONFIG_H'
       ],
+      'cflags': [
+        '-Wno-missing-field-initializers'
+      ],
+      'xcode_settings': {
+        'OTHER_CFLAGS': [
+          '-Wno-missing-field-initializers'
+        ]
+      },
       'include_dirs': [
         '.',
         'lib',

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   },
   "dependencies": {
     "bindings": "^1.2.1",
-    "debug": "^2.2.0",
-    "iconv": "^2.1.10",
-    "nan": "^2.0.9"
+    "nan": "^2.1.0"
   },
   "devDependencies": {
+    "debug": "^2.2.0",
+    "iconv": "^2.1.10",
     "vows": "^0.8.1"
   },
   "repository": "github:node-xmpp/node-expat",


### PR DESCRIPTION
Hello, thanks for maintaining the Node bindings for expat.

Here are fixes for a few things I ran into when first running `npm i && npm t` on a clone of the `master` branch.

* Add missing `standard` devDependency
* Ensure `iconv` is a devDependency - see #129
* Silence pedantic expat compile-time warnings

Cheers,
Lovell